### PR TITLE
Fix, refactor & extend debug binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "autocfg"
@@ -124,6 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -132,8 +177,22 @@ version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -141,6 +200,12 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "crc32fast"
@@ -293,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +443,7 @@ dependencies = [
 name = "okmain"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "criterion",
  "fast-srgb8",
  "image",
@@ -396,6 +468,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oorandom"
@@ -729,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +844,12 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/crates/okmain/Cargo.toml
+++ b/crates/okmain/Cargo.toml
@@ -12,6 +12,7 @@ fast-srgb8 = { version = "1" }
 rand = { version = "0.10.0", default-features = false }
 rand_xoshiro = { version = "0.8" }
 image = { version = "0.25", optional = true, default-features = false }
+clap = { version = "4", features = ["derive"], optional = true }
 rgb = { version = "0.8" }
 
 [dev-dependencies]
@@ -24,7 +25,7 @@ default = []
 image = ["dep:image"]
 unstable = []
 # opens up private modules for debug binaries and benchmarks
-_debug = []
+_debug = ["dep:clap", "image/png", "image/jpeg"]
 
 [package.metadata.docs.rs]
 # Not `all-features` because `_debug` is internal
@@ -40,6 +41,10 @@ required-features = ["image", "_debug"]
 
 [[bin]]
 name = "debug_colors"
+required-features = ["image", "_debug"]
+
+[[bin]]
+name = "debug_distance_mask"
 required-features = ["image", "_debug"]
 
 [[bench]]

--- a/crates/okmain/src/bin/debug_distance_mask.rs
+++ b/crates/okmain/src/bin/debug_distance_mask.rs
@@ -1,0 +1,46 @@
+use clap::Parser;
+use image::GrayImage;
+use okmain::DEFAULT_MASK_SATURATED_THRESHOLD;
+use std::path::PathBuf;
+
+#[derive(Parser)]
+struct Args {
+    /// Image width in pixels
+    #[arg(long, default_value_t = 500)]
+    width: u16,
+
+    /// Image height in pixels
+    #[arg(long, default_value_t = 700)]
+    height: u16,
+
+    /// Saturated threshold for the mask
+    #[arg(long, default_value_t = DEFAULT_MASK_SATURATED_THRESHOLD)]
+    threshold: f32,
+
+    /// Output file path
+    #[arg(short, long, default_value = "distance_mask.png")]
+    output: PathBuf,
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let mut img = GrayImage::new(args.width as u32, args.height as u32);
+
+    for y in 0..args.height {
+        for x in 0..args.width {
+            let value = okmain::distance_mask(args.threshold, args.width, args.height, x, y);
+            let pixel = (value * 255.0).round() as u8;
+            img.put_pixel(x as u32, y as u32, image::Luma([pixel]));
+        }
+    }
+
+    img.save(&args.output).unwrap();
+    println!(
+        "Saved {}x{} distance mask (threshold={}) to {}",
+        args.width,
+        args.height,
+        args.threshold,
+        args.output.display(),
+    );
+}

--- a/crates/okmain/src/bin/debug_sample.rs
+++ b/crates/okmain/src/bin/debug_sample.rs
@@ -1,33 +1,23 @@
+use clap::Parser;
 use image::RgbImage;
+use okmain::debug_helpers::{ensure_out_dir, find_jpg_files, load_rgb8, FolderArgs};
 use okmain::sample;
-use std::path::PathBuf;
 use std::time::Instant;
 
+#[derive(Parser)]
+struct Args {
+    #[command(flatten)]
+    folder: FolderArgs,
+}
+
 fn main() {
-    let args: Vec<String> = std::env::args().collect();
-    if args.len() != 2 {
-        eprintln!("usage: {} <folder>", args[0]);
-        std::process::exit(1);
-    }
-    let folder = PathBuf::from(&args[1]);
-
-    let mut files: Vec<PathBuf> = std::fs::read_dir(&folder)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| {
-            p.extension()
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("jpg"))
-        })
-        .collect();
-    files.sort();
-
-    let out_dir = folder.join("debug_results/sample");
-    std::fs::create_dir_all(&out_dir).unwrap();
+    let args = Args::parse();
+    let files = find_jpg_files(&args.folder.folder);
+    let out_dir = ensure_out_dir(&args.folder.folder, "sample");
 
     for path in &files {
         let filename = path.file_name().unwrap();
-        let img = image::open(path).unwrap().to_rgb8();
+        let img = load_rgb8(path);
         let (w, h) = (img.width() as u16, img.height() as u16);
 
         let t = Instant::now();

--- a/crates/okmain/src/debug_helpers.rs
+++ b/crates/okmain/src/debug_helpers.rs
@@ -1,0 +1,33 @@
+use clap::Parser;
+use image::RgbImage;
+use std::path::{Path, PathBuf};
+
+#[derive(Parser)]
+pub struct FolderArgs {
+    /// Path to a folder of images
+    pub folder: PathBuf,
+}
+
+pub fn find_jpg_files(folder: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(folder)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("jpg"))
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+pub fn ensure_out_dir(folder: &Path, name: &str) -> PathBuf {
+    let dir = folder.join("debug_results").join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+pub fn load_rgb8(path: &Path) -> RgbImage {
+    image::open(path).unwrap().to_rgb8()
+}

--- a/crates/okmain/src/lib.rs
+++ b/crates/okmain/src/lib.rs
@@ -13,6 +13,8 @@ mod rng;
 pub mod sample;
 #[cfg(not(feature = "_debug"))]
 mod sample;
+#[cfg(feature = "_debug")]
+pub mod debug_helpers;
 
 use oklab::{oklab_to_srgb, Oklab};
 pub use rgb;
@@ -48,8 +50,8 @@ pub const DEFAULT_WEIGHTED_COUNTS_WEIGHT: f32 = 0.3;
 pub const DEFAULT_CHROMA_WEIGHT: f32 = 0.7;
 
 // todo: verify
-#[inline]
-fn distance_mask(saturated_threshold: f32, width: u16, height: u16, x: u16, y: u16) -> f32 {
+#[inline(always)]
+fn distance_mask_impl(saturated_threshold: f32, width: u16, height: u16, x: u16, y: u16) -> f32 {
     let width = width as f32;
     let height = height as f32;
     let x = x as f32;
@@ -69,6 +71,18 @@ fn distance_mask(saturated_threshold: f32, width: u16, height: u16, x: u16, y: u
     let y_contribution = f32::min(0.1 + 0.9 * (y / y_threshold), 1.0);
 
     f32::min(x_contribution, y_contribution)
+}
+
+#[cfg(feature = "_debug")]
+#[inline]
+pub fn distance_mask(saturated_threshold: f32, width: u16, height: u16, x: u16, y: u16) -> f32 {
+    distance_mask_impl(saturated_threshold, width, height, x, y)
+}
+
+#[cfg(not(feature = "_debug"))]
+#[inline]
+fn distance_mask(saturated_threshold: f32, width: u16, height: u16, x: u16, y: u16) -> f32 {
+    distance_mask_impl(saturated_threshold, width, height, x, y)
 }
 
 /// Errors that can occur when constructing an [`InputImage`].


### PR DESCRIPTION
## Summary

- **Fix** `debug_colors.rs` — replaced broken `colors_from_image` import with `InputImage::try_from` + `colors`
- **Add clap** for arg parsing across all debug binaries, replacing manual `std::env::args` boilerplate
- **Extract shared helpers** into `debug_helpers` module (`FolderArgs`, `find_jpg_files`, `ensure_out_dir`, `load_rgb8`)
- **Add `debug_distance_mask` binary** — generates a grayscale PNG visualizing the center-priority mask
- **Expose `distance_mask`** as `pub` under `_debug` feature for the new binary
- **Gate image codecs** (`png`, `jpeg`) on `_debug` feature so binaries can encode/decode without relying on dev-dependency feature unification

## Test plan

- [x] `cargo build -p okmain --features image,_debug` — all 4 binaries compile
- [x] `cargo clippy -p okmain --all-features -- -D warnings` — no warnings
- [x] `cargo test -p okmain --features image` — all existing tests pass (3 pre-existing `distance_weight_*` failures unchanged)
- [x] `cargo run -p okmain --features image,_debug --bin debug_distance_mask` — produces valid PNG