### PR TITLE
Rewrite AGENTS.md files for minimal, actionable agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,41 @@
 # okmain — Dominant Color Extraction
 
-## Overview
+Extract dominant colors from images. Ships as a Rust crate (`okmain` on crates.io) and Python package (`okmain` on PyPI, built with maturin/PyO3).
 
-Extract dominant colors from images. Ships as:
-- A **Rust crate** (`okmain`) on crates.io
-- A **Python package** (`okmain`) on PyPI via maturin/PyO3
-
-## Workspace Layout
+## Workspace layout
 
 ```
 okmain/
 ├── crates/okmain/      # Pure Rust library (published to crates.io)
-├── crates/okmain_py/   # PyO3 wrapper (NOT published to crates.io)
+├── crates/okmain_py/   # PyO3 wrapper (never published to crates.io)
 └── python/             # Python package (published to PyPI)
 ```
 
-**Key architectural rule:** the core Rust crate (`crates/okmain`) has **zero PyO3 knowledge**. All PyO3 bindings live in `crates/okmain_py/`. This keeps core tests independent of the Python runtime, improves compile times, and separates concerns cleanly.
+## Invariants — never break these
 
-## Tooling
+- `crates/okmain` has **zero PyO3 knowledge**. All Python bindings live in `crates/okmain_py/`.
+- `crates/okmain_py/src/lib.rs` is a **thin translation layer only** — no business logic.
+- Input validation for Python callers (e.g., RGBA rejection) lives in `python/okmain/__init__.py`, not in Rust.
 
-| Tool      | Purpose                          |
-|-----------|----------------------------------|
-| `just`    | Task runner (`justfile` at root) |
-| `uv`      | Python project/env management    |
-| `maturin` | Build PyO3 extension             |
-| `ruff`    | Python linting & formatting      |
-| `mypy`    | Python type checking             |
+## Commands
 
-**uv workspace:** The root `pyproject.toml` defines a uv workspace with `python/` as a member. Run `uv sync`, `uv run pytest`, `uv run ruff`, etc. from the **repo root** — no need to `cd python` first.
+```sh
+just test         # all tests (Rust + Python)
+just lint         # all linters (Rust + Python)
+just develop      # rebuild maturin extension (required before Python tests after any Rust change)
+just fmt          # auto-format everything
+```
 
-## Conventions
+Individual targets: `just test-rust`, `just test-python`, `just lint-rust`, `just lint-python`.
+Run `uv sync`, `uv run pytest`, etc. from the **repo root** (uv workspace).
 
-- **Rust edition:** 2024, resolver 3, MSRV 1.93
-- **License:** MIT OR Apache-2.0 (dual license, both files in repo root)
-- **Error handling (core crate):** `snafu` 0.8 internally; public API is snafu-agnostic by default
+## Settings
 
-## Sub-directory Guides
+- **Rust edition:** 2024 · **MSRV:** 1.93 · **resolver:** 3 · **license:** MIT OR Apache-2.0
+- **Python:** ≥3.12 · **mypy:** strict · **line length:** 99
 
-- [`crates/okmain/AGENTS.md`](crates/okmain/AGENTS.md) — Core Rust crate guidance
-- [`python/AGENTS.md`](python/AGENTS.md) — Python/PyO3 wrapper guidance
+## Sub-guides
+
+- [`crates/okmain/AGENTS.md`](crates/okmain/AGENTS.md) — Core Rust crate
+- [`crates/okmain_py/AGENTS.md`](crates/okmain_py/AGENTS.md) — PyO3 wrapper
+- [`python/AGENTS.md`](python/AGENTS.md) — Python package

--- a/crates/okmain/AGENTS.md
+++ b/crates/okmain/AGENTS.md
@@ -1,52 +1,46 @@
 # Core Crate — `okmain`
 
-## Rules
+## Constraints
 
-- **No PyO3 dependency.** This crate must never depend on `pyo3`. All Python bindings live in `python/`.
-- **Error handling:** Use `snafu` 0.8 (with `rust_1_81` feature) internally. The public `Error` type is a normal
-  `std::error::Error` — consumers don't need snafu.
-- **Optional `snafu` feature:** When enabled, re-exports `snafu` and makes context selectors public.
-- **Optional `image` feature:** Gates `dominant_color_from_image` and the `image` dependency.
-- Tests use `pretty_assertions`
-- **RNG:** Abstracted behind `rng::new()`. To change the RNG algorithm or seed, only modify `src/rng.rs`.
+- **No PyO3 dependency** — ever. All Python bindings live in `crates/okmain_py/`.
+- **Error handling:** `snafu` 0.8 internally (`rust_1_81` feature). Validate with `ensure!`. Public `Error` types are plain `std::error::Error`.
+- Mark all public enums `#[non_exhaustive]`.
+- Feature gate conventions:
+  - `image` — optional `image` crate dep; gates `dominant_color_from_image`
+  - `unstable` — public but experimental API (`colors_debug`, `ScoredCentroid`, etc.)
+  - `_debug` — internal only (debug binaries + benches); never mention in public docs
+- **RNG:** only touch `src/rng.rs` to change the algorithm or seed.
 
 ## Testing
 
 ```sh
-cargo nextest -p okmain                   # default features
-cargo nextest -p okmain --features image  # with image support
+cargo nextest run -p okmain                              # default features
+cargo nextest run -p okmain --features image             # with image support
+cargo nextest run -p okmain --features image,unstable
+cargo test --doc -p okmain --features image              # doc tests
 ```
 
-## Public API Surface
+Use `pretty_assertions` for all equality assertions. Test helpers live in the same file as the tests they support.
 
-Keep it snafu-agnostic by default. Only expose snafu internals behind the `snafu` crate feature.
+## Code style
 
-## Code Style
+Style reference for the k-means module: `src/kmeans/lloyds.rs`.
 
-Style reference for the k-means module: `lloyds.rs`.
+### Data layout
+Data is SoA (`SampledOklabSoA`, `CentroidSoA`). Write functions that operate on SoA directly — don't convert to AoS at call boundaries.
 
-### Be concise
-Every line should do real work. Don't add intermediate variables, wrapper structs, or control flow that doesn't earn its keep. Directly index SoA arrays instead of constructing a temporary struct to pass to a helper. Fewer lines of straightforward code beat more lines of "clean" code.
+### Conciseness
+Every line earns its keep. Index SoA arrays directly instead of constructing a temporary struct to pass to a helper. Fewer clear lines beat more "clean" lines.
 
-### Factor out hot paths for benchmarking
-Expensive inner loops (`assign_points`, `update_centroids`) must be separate `pub` functions so criterion benchmarks can target them individually. Don't bury performance-critical work inside a monolithic function where it can't be measured in isolation.
+### Hot paths
+Expensive inner loops (`assign_points`, `update_centroids`) must be `pub fn` so benchmarks can target them individually. Use `#[inline(always)]` on leaf scalar functions called in the innermost loop (e.g., `squared_distance_flat`); use `#[inline]` on larger but still hot functions.
 
-### Match the data representation
-Data here is SoA (`SampledOklabSoA`). Write functions that operate on SoA directly. Don't convert between layouts at call boundaries — e.g. don't build an AoS struct from SoA fields just to pass it to a function that immediately destructures it back into components.
+### Algorithm/policy separation
+The iteration loop does math. Initialization, output formatting, and retry policy belong to the caller.
 
-### No scaffolding in shipped code
-No `println!` debug output. No dead code kept around with `let _ = unused;`. No commented-out alternative implementations. Code should be clean enough to ship as-is.
+## Common LLM anti-patterns
 
-### Don't over-engineer edge cases
-If `count == 0` is the right check, write `count == 0`. Don't build a threshold heuristic with several intermediate variables that ultimately does the same thing with more code.
-
-### Separate algorithm steps from policy
-The iteration loop does the math. It doesn't also do initialization or output format conversion. Callers own the policy — which init strategy to use, how to package results, when to retry. Inner functions own the computation.
-
-### Common LLM anti-patterns to avoid
-
-- **Monolithic "do everything" functions** that bundle initialization, iteration, convergence checking, and output conversion into one block. Split them so each piece is testable and benchmarkable.
-- **Layout conversion at call boundaries.** Writing `nearest_centroid(point: &Oklab, ...)` when the caller has SoA data forces a struct construction at every call site. Pass scalar components or slice references instead.
-- **Allocating inside loops.** `Vec::with_capacity(n)` + `.push()` in every iteration of a convergence loop. Pre-allocate once, pass `&mut [u8]`, reuse.
-- **Hedging with dead code.** Computing a value "just in case" and then suppressing the unused warning with `let _ = x;`. Delete it.
-- **Complexity as a proxy for correctness.** Adding threshold heuristics, smoothing, or multi-step logic where a trivial check suffices. Simple code is easier to verify.
+- **Monolithic functions** bundling init + iteration + convergence check + output conversion. Split them — each piece should be testable and benchmarkable independently.
+- **AoS at call boundaries** — writing `fn nearest_centroid(point: &Oklab, ...)` when the caller has SoA forces a struct construction at every call site. Pass scalar components or slice references instead.
+- **Allocating inside loops** — `Vec::with_capacity` + `.push()` in every convergence iteration. Pre-allocate once, pass `&mut [T]`, reuse.
+- **Spurious complexity** — threshold heuristics and multi-step logic where a simple check suffices. Simple code is easier to verify.

--- a/crates/okmain_py/AGENTS.md
+++ b/crates/okmain_py/AGENTS.md
@@ -1,0 +1,32 @@
+# PyO3 Wrapper — `okmain_py`
+
+Translates between Rust types and Python-friendly types. Contains **no business logic**.
+
+## Constraints
+
+- One file only: `src/lib.rs`. No sub-modules, no algorithm code.
+- Never published to crates.io (`publish = false`).
+- All symbols exported to Python use a `_` prefix (e.g., `_colors_debug`, `_ScoredCentroid`, `_DebugInfo`) to signal they are internal to `okmain._core`.
+
+## Type translation rules
+
+| Rust | Python (in `_core.pyi`) |
+|------|-------------------------|
+| Named struct (e.g., `Oklab`) | Plain tuple (e.g., `tuple[float, float, float]`) |
+| `Vec<T>` | `list[T]` |
+| `Result<_, E>` | Raise `PyValueError` with the error's `Display` string |
+
+The Python layer (`python/okmain/__init__.py`) is responsible for wrapping raw tuples into typed frozen dataclasses.
+
+## Update checklist
+
+When changing the Rust interface:
+
+1. Edit `src/lib.rs`.
+2. Update `python/okmain/_core.pyi` to match — this is what mypy checks.
+3. Update `python/okmain/__init__.py` if new data needs wrapping.
+4. `just develop && just test-python`
+
+## Lint notes
+
+`#[allow(clippy::too_many_arguments)]` is expected on functions mirroring the `colors_with_config` signature.

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -1,28 +1,85 @@
-# Python/PyO3 Wrapper — `okmain_py`
+# Python Package — `okmain`
 
-## Rules
+## Architecture
 
-- The Rust PyO3 crate lives at `crates/okmain_py/` and is **never published** to crates.io (`publish = false`).
-- `crates/okmain_py/src/lib.rs` is a **thin PyO3 wrapper only** — no business logic.
-- Python source lives in `python/okmain/`.
-- RGBA rejection happens in the Python layer (`__init__.py`), not in Rust.
+- `python/okmain/__init__.py` — the entire public API
+- `python/okmain/_core.pyi` — type stub for the compiled Rust extension (keep in sync with `crates/okmain_py/src/lib.rs`)
+- `crates/okmain_py/src/lib.rs` — the PyO3 Rust code that backs `_core`
 
-## Development
+**Validation rule:** input validation (e.g., `image.mode != "RGB"`) lives in `__init__.py`, not in Rust.
 
-All commands run from the **repo root** (uv workspace):
-
-```sh
-uv sync                                # set up venv + deps
-just develop                           # build extension (maturin)
-uv run pytest python/tests/ -v         # run tests
-uv run ruff check python/              # lint
-uv run ruff format --check python/     # format check
-uv run mypy python/okmain              # type check
-```
-
-## Build
+## Commands (all from repo root)
 
 ```sh
-cd python && uv run maturin develop    # dev build (editable)
-cd python && uv run maturin build      # release wheel
+just develop                         # rebuild Rust extension after any Rust change
+uv run pytest python/tests/ -v       # tests
+uv run mypy python/okmain            # type check (strict mode)
+uv run ruff check python/            # lint
+uv run ruff format python/           # format
 ```
+
+## Code style
+
+### Public types — frozen dataclasses with slots
+
+```python
+@dataclass(frozen=True, slots=True)
+class RGB:
+    r: int
+    g: int
+    b: int
+```
+
+Every public type follows this pattern. No mutable classes, no plain dicts.
+
+### Converting `_core` types — `_from_core` classmethod
+
+Raw `_core` tuples are wrapped into typed dataclasses via a `_from_core` classmethod:
+
+```python
+@classmethod
+def _from_core(cls, sc: _ScoredCentroid) -> Self:
+    rgb_r, rgb_g, rgb_b = sc.rgb
+    lab_l, lab_a, lab_b = sc.oklab
+    return cls(rgb=RGB(rgb_r, rgb_g, rgb_b), oklab=Oklab(lab_l, lab_a, lab_b), ...)
+```
+
+### Overloads for type-narrowing polymorphism
+
+When a boolean flag changes the return type, use `@overload` + `Literal`:
+
+```python
+@overload
+def colors(..., with_debug: Literal[True]) -> tuple[list[RGB], DebugInfo]: ...
+@overload
+def colors(..., with_debug: Literal[False] = ...) -> list[RGB]: ...
+```
+
+### Other conventions
+
+- `from __future__ import annotations` at the top of every module.
+- All optional config parameters are keyword-only (after `*`).
+- Explicit `__all__` in `__init__.py` listing every public symbol.
+
+## Tests
+
+pytest, no fixtures, all test functions annotated `-> None`.
+
+```python
+def test_rgba_raises() -> None:
+    img = Image.new("RGBA", (2, 2), (255, 0, 0, 255))
+    with pytest.raises(ValueError, match="RGBA"):
+        okmain.colors(img)
+```
+
+Cover: happy path, error cases (wrong mode, invalid config), debug mode, result ordering. Use `match=` on `pytest.raises` to assert the error message text.
+
+## Recipe: adding a new public type
+
+1. Add to `crates/okmain_py/src/lib.rs` (return as tuple, not a Python class).
+2. Update `python/okmain/_core.pyi` with the matching stub.
+3. Add a `@dataclass(frozen=True, slots=True)` class in `__init__.py` with a `_from_core` classmethod.
+4. Add to `__all__`.
+5. Wire into `__init__.py` conversion code.
+6. Add tests.
+7. `just develop && just test-python && uv run mypy python/okmain`


### PR DESCRIPTION
## Summary

- **Root `AGENTS.md`**: replaced tooling table + prose with an explicit **Invariants** section and consolidated command reference; added missing `crates/okmain_py/` sub-guide link
- **`crates/okmain/AGENTS.md`**: added feature gate conventions (`image`/`unstable`/`_debug`), `#[non_exhaustive]` rule, `#[inline]` guidance for hot paths, corrected `nextest run` invocation, all-feature doc test command
- **`crates/okmain_py/AGENTS.md`**: new file — type translation contract (Rust struct → plain tuple, `Result` → `PyValueError`), `_` prefix naming convention, update checklist
- **`python/AGENTS.md`**: expanded from thin dev-commands doc to full guide covering architecture, frozen-dataclass pattern, `_from_core` classmethod, `@overload` + `Literal` recipe, test style, and step-by-step add-type recipe

## Test plan

- [ ] `just lint` passes clean
- [ ] `just test` passes clean
- [ ] `CLAUDE.md` symlink still resolves to `AGENTS.md`
- [ ] `crates/okmain_py/AGENTS.md` is a regular file (not a symlink)